### PR TITLE
chore: derive Copy and Clone for structs we added

### DIFF
--- a/src/task_info.rs
+++ b/src/task_info.rs
@@ -28,7 +28,7 @@ pub const TASK_BASIC_INFO_COUNT: mach_msg_type_number_t = 8;
 
 pub const MIG_ARRAY_TOO_LARGE: kern_return_t = -307;
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 #[repr(C)]
 #[repr(packed)]
 pub struct task_basic_info {
@@ -54,7 +54,7 @@ impl task_basic_info {
   }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 #[repr(C)]
 #[repr(packed)]
 pub struct task_events_info {

--- a/src/time_value.rs
+++ b/src/time_value.rs
@@ -4,7 +4,7 @@ use vm_types::{integer_t};
 
 const TIME_MICROS_MAX: integer_t = 1000000;
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 #[repr(C)]
 #[repr(packed)]
 pub struct time_value {


### PR DESCRIPTION
## Description
- Derive `Copy` and `Clone` for structs we added (`Clone` required for `Copy`)

This is to resolve unaligned references errors when building on rustc 1.62.0 or later.